### PR TITLE
performのidを持たせるようにした

### DIFF
--- a/lib/perform_config.json
+++ b/lib/perform_config.json
@@ -23,6 +23,10 @@
     "meta": {
       "type": "object",
       "description": "Meta data of this"
+    },
+    "pid": {
+      "type": "string",
+      "description": "Id of performing"
     }
   },
   "additionalProperties": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sg-schemas",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Scheams for SUGOS",
   "main": "lib",
   "browser": "shim/browser",


### PR DESCRIPTION
sugo-hubを冗長化するとackが使えなくなりメソッド実行と結果返却をわけなくなければなったので。
performの識別子を持たせるようにした